### PR TITLE
fix: shiki causes fatal error on hexo 7

### DIFF
--- a/lib/highlighter/index.js
+++ b/lib/highlighter/index.js
@@ -60,22 +60,6 @@ function filterIntoShiki(
   return cleanup(renderCodeBlock(codeHtml, lang), backgroundColor);
 }
 
-function parseFence(infoString) {
-  if (!infoString) {
-    return {
-      lang: defaultLang,
-      meta: {}
-    };
-  }
-
-  const tokens = lex(infoString);
-
-  return {
-    lang: tokens.shift() ?? '',
-    meta: parse(tokens)
-  };
-}
-
 // Register to the marked markdown renderer that we want to take over
 // rendering code blocks
 // Temporary 'deasync' method, can use `hexo.extend.highlight` in Hexo 7+
@@ -122,9 +106,8 @@ module.exports = (hexo) => {
       }
     }
 
-    renderer.code = function (code, infoString) {
-      fenceData = parseFence(infoString);
-      return filterIntoShiki(highlighter, code, fenceData.lang, {
+    renderer.code = function (code) {
+      return filterIntoShiki(highlighter, code.text, fenceData.lang, {
         theme: codeTheme,
         backgroundColor
       });


### PR DESCRIPTION
Enable shiki will cause a `TypeError: code.split is not a function` error and prevents the blog from generating or serving on hexo 7.3.0 and hexo-renderer-marked 7.0.0. The API has changed and no longer provides an info string, which is embedded into the `code` argument.